### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/shubham-pawar/FoodMine/security/code-scanning/1](https://github.com/shubham-pawar/FoodMine/security/code-scanning/1)

In general, the fix is to explicitly add a `permissions` block that grants only the scopes required by the workflow. Since this job only checks out code, sets up Node.js, installs dependencies, and builds, it only needs read access to repository contents (and no write access).

The best minimal change is to add `permissions: contents: read` at the workflow root (top level, alongside `name` and `on`) so it applies to all jobs that don’t override it. This avoids changing functionality while constraining the default `GITHUB_TOKEN`. Concretely: edit `.github/workflows/main.yml` and insert:

```yaml
permissions:
  contents: read
```

between the `name: CI` line and the `on:` block (or anywhere at the root level before `jobs:`). No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
